### PR TITLE
Poll enhancements

### DIFF
--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -40,7 +40,7 @@ POLL_CONTROL_EMOJI = (
 POLL_COLOR = 0x009fe3
 
 # Number of polls per page
-POLLS_PER_PAGE = 10
+POLLS_PER_PAGE = 5
 
 # Emoji for showing polls
 FIRST_PAGE_EMOJI = '⏮'

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -202,7 +202,7 @@ class PollsCog(commands.Cog, name="Polls"):
 
         # Removes all reactions but the delete poll reaction
         for reaction in message.reactions:
-            if str(reaction.emoji) == END_POLL_EMOJI:
+            if str(reaction.emoji) == DELETE_POLL_EMOJI:
                 continue
             await message.remove_reaction(reaction.emoji, self.bot.user)
 

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -30,7 +30,7 @@ DELETE_POLL_EMOJI = '✖️'
 END_POLL_EMOJI = '🛑'
 
 # Tuple of control emoji for convenience
-CONTROL_EMOJI = (
+POLL_CONTROL_EMOJI = (
     ADD_CHOICE_EMOJI,
     DELETE_POLL_EMOJI,
     END_POLL_EMOJI
@@ -42,6 +42,21 @@ POLL_COLOR = 0x009fe3
 # Number of polls per page
 POLLS_PER_PAGE = 10
 
+# Emoji for showing polls
+FIRST_PAGE_EMOJI = '⏮'
+PREVIOUS_PAGE_EMOJI = '⏪'
+CLEAR_EMOJI = '⏹️'
+NEXT_PAGE_EMOJI = '⏩'
+LAST_PAGE_EMOJI = '⏭️'
+
+# Tuple of emoji for convenience
+SHOW_POLLS_EMOJI = (
+    FIRST_PAGE_EMOJI,
+    PREVIOUS_PAGE_EMOJI,
+    CLEAR_EMOJI,
+    NEXT_PAGE_EMOJI,
+    LAST_PAGE_EMOJI,
+)
 
 class PollsCog(commands.Cog, name="Polls"):
     """Class for polls cog"""
@@ -90,7 +105,7 @@ class PollsCog(commands.Cog, name="Polls"):
 
         if error_msg is None:
             reaction, text = values
-            if reaction in CONTROL_EMOJI:
+            if reaction in POLL_CONTROL_EMOJI:
                 error_msg = f"You can't use {reaction} as a choice."
             elif poll.choices().where('reaction', reaction).first():
                 error_msg = f"Choice already exists for {reaction}."
@@ -314,6 +329,8 @@ class PollsCog(commands.Cog, name="Polls"):
 
         if message is None:
             message = await channel.send(embed=embed)
+            for emoji in SHOW_POLLS_EMOJI:
+                await message.add_reaction(emoji)
 
     @tasks.loop(seconds=1.0)
     async def poll_daemon(self):
@@ -389,7 +406,7 @@ class PollsCog(commands.Cog, name="Polls"):
         except discord.errors.NotFound:
             pass
 
-        if emoji.name not in CONTROL_EMOJI:
+        if emoji.name not in POLL_CONTROL_EMOJI:
             await self.update_response_counts(poll)
 
     @commands.command(
@@ -413,7 +430,7 @@ class PollsCog(commands.Cog, name="Polls"):
         message = await ctx.send(embed=embed)
 
         # Adds control emojis
-        for emoji in CONTROL_EMOJI:
+        for emoji in POLL_CONTROL_EMOJI:
             await message.add_reaction(emoji)
 
         # Deletes the original command message

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -343,7 +343,7 @@ class PollsCog(commands.Cog, name="Polls"):
                 + ("Poll has ended" if poll.ended
                    else ut.get_uk_time(poll.end_date).strftime(
                        "Poll ends: %d/%m/%Y %H:%M:%S %Z"))
-                + f"\nPoll ID: {poll.id}.")
+                + f"\nPoll ID: {poll.id}")
 
             embed.add_field(
                 name=f"{poll.title}", value=field_value, inline=False)
@@ -352,9 +352,9 @@ class PollsCog(commands.Cog, name="Polls"):
         last_poll = first_poll + polls.count() - 1
         total = polls.total
 
-        embed.set_footer(text=f"Showing polls {first_poll} - {last_poll} "
-                              f"of {total}\n"
-                              f"Page {page} of {polls.last_page}")
+        embed.set_footer(
+            text=f"Showing polls {first_poll} - {last_poll} of {total}\n"
+                 f"Page {page} of {polls.last_page}")
 
         if message is None:
             message = await channel.send(embed=embed)

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -323,8 +323,11 @@ class PollsCog(commands.Cog, name="Polls"):
         embed = discord.Embed(title="Your Polls", color=POLL_COLOR)
         for poll in polls:
             field_value = (
-                f"Poll ID: {poll.id}. This poll "
-                + ("has ended" if poll.ended else "is ongoing"))
+                f"by <@!{poll.creator_id}>\n"
+                f"Poll ID: {poll.id}. "
+                + ("Poll has ended" if poll.ended
+                   else ut.get_uk_time(poll.end_date).strftime(
+                       "Poll ends: %d/%m/%Y %H:%M:%S %Z\n")))
 
             embed.add_field(
                 name=f"{poll.title}", value=field_value, inline=False)

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -360,6 +360,30 @@ class PollsCog(commands.Cog, name="Polls"):
             except discord.errors.NotFound:
                 pass
 
+        try:
+            reaction, _ = await self.bot.wait_for(
+                'reaction_add', check=check, timeout=60.0)
+        except asyncio.TimeoutError:
+            await message.delete()
+            return
+
+        emoji = reaction.emoji
+        if emoji == CLEAR_POLLS_EMOJI:
+            await message.delete()
+            return
+
+        if emoji == FIRST_PAGE_EMOJI:
+            page = 1
+        elif emoji == PREVIOUS_PAGE_EMOJI:
+            page -= 1
+        elif emoji == NEXT_PAGE_EMOJI:
+            page += 1
+        elif emoji == LAST_PAGE_EMOJI:
+            page = polls.last_page
+
+        await reaction.remove(user)
+        await self.user_show_polls(user, channel, message=message, page=page)
+
     @tasks.loop(seconds=1.0)
     async def poll_daemon(self):
         """

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -495,7 +495,7 @@ class PollsCog(commands.Cog, name="Polls"):
 
     @commands.command(
         name="summonpoll",
-        help="Moves an existing poll to the bottom of the channel")
+        help="Summons a poll forward in, or back into, the channel")
     async def summon_poll(self, ctx, poll_id: int):
         """
         Allows a user to bring forward a poll in the conversation,

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -129,8 +129,7 @@ class PollsCog(commands.Cog, name="Polls"):
 
     async def user_delete_poll(self, poll, message, user: discord.User):
         # Only the creator of the poll or admins can delete it
-        if (poll.creator_id != user.id
-                and not await ut.is_admin(user)):
+        if poll.creator_id != user.id and not ut.is_admin(user):
             return
 
         # Awaits confirmation of the deletion
@@ -184,8 +183,7 @@ class PollsCog(commands.Cog, name="Polls"):
 
     async def user_end_poll(self, poll, message, user: discord.User):
         # Only the creator of the poll can end the poll
-        if (poll.creator_id != user.id
-                and not await ut.is_admin(user)):
+        if poll.creator_id != user.id and not ut.is_admin(user):
             return
 
         result, reason = await ut.get_confirmation(
@@ -196,7 +194,7 @@ class PollsCog(commands.Cog, name="Polls"):
         #
         # The poll will end the poll on its next iteration
         if result:
-            poll.end_date = await ut.get_utc_time()
+            poll.end_date = ut.get_utc_time()
             poll.save()
 
     async def update_response_counts(self, poll):
@@ -241,7 +239,7 @@ class PollsCog(commands.Cog, name="Polls"):
             embed.add_field(name=f"{choice.reaction} {count}",
                             value=field_value, inline=False)
 
-        embed.timestamp = await ut.get_utc_time()
+        embed.timestamp = ut.get_utc_time()
         embed.set_footer(text=f"Poll ID: {poll.id}")
 
         # Again, if the message is deleted
@@ -256,7 +254,7 @@ class PollsCog(commands.Cog, name="Polls"):
             description = ("Poll has now ended\n"
                            "React with ✖️ to delete the poll")
         else:
-            description = (await ut.get_uk_time(end_date)).strftime(
+            description = ut.get_uk_time(end_date).strftime(
                 "Poll ends: %d/%m/%Y %H:%M:%S %Z\n") + (
                 "React with ➕ to add a choice\n"
                 "React with ✖️ to delete the poll\n"
@@ -280,7 +278,7 @@ class PollsCog(commands.Cog, name="Polls"):
         try:
             ongoing_polls = Poll.where('ended', False).get()
             for poll in ongoing_polls:
-                if await ut.get_utc_time() >= poll.end_date:
+                if ut.get_utc_time() >= poll.end_date:
                     await self.end_poll(poll)
         except Exception:
             traceback.print_exc()
@@ -322,7 +320,7 @@ class PollsCog(commands.Cog, name="Polls"):
 
         # New responses after the poll has ended are not accepted
         end_date = poll.end_date
-        if (await ut.get_utc_time()) >= end_date or poll.ended:
+        if ut.get_utc_time() >= end_date or poll.ended:
             try:
                 await message.remove_reaction(emoji, user)
             except discord.errors.NotFound:
@@ -361,7 +359,7 @@ class PollsCog(commands.Cog, name="Polls"):
                            "that is greater than zero")
             return
 
-        end_date = await ut.get_utc_time() + duration
+        end_date = ut.get_utc_time() + duration
         embed = await self.create_poll_embed(title, end_date, False)
         message = await ctx.send(embed=embed)
 
@@ -394,8 +392,7 @@ class PollsCog(commands.Cog, name="Polls"):
             await ctx.send(f"Poll with ID {poll_id} could not found.")
             return
 
-        if (ctx.author.id != poll.creator_id
-                and not await ut.is_admin(ctx.author)):
+        if ctx.author.id != poll.creator_id and not ut.is_admin(ctx.author):
             await ctx.send("You don't have permission to summon that poll!")
 
         old_channel = self.bot.get_channel(poll.channel_id)

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -58,6 +58,7 @@ SHOW_POLLS_EMOJI = (
     LAST_PAGE_EMOJI,
 )
 
+
 class PollsCog(commands.Cog, name="Polls"):
     """Class for polls cog"""
 
@@ -334,31 +335,10 @@ class PollsCog(commands.Cog, name="Polls"):
 
         if message is None:
             message = await channel.send(embed=embed)
+            for emoji in SHOW_POLLS_EMOJI:
+                await message.add_reaction(emoji)
         else:
             await message.edit(embed=embed)
-
-        if page != 1:
-            await message.add_reaction(FIRST_PAGE_EMOJI)
-            await message.add_reaction(PREVIOUS_PAGE_EMOJI)
-        else:
-            try:
-                await message.remove_reaction(FIRST_PAGE_EMOJI, self.bot.user)
-                await message.remove_reaction(
-                    PREVIOUS_PAGE_EMOJI, self.bot.user)
-            except discord.errors.NotFound:
-                pass
-
-        await message.add_reaction(CLEAR_POLLS_EMOJI)
-
-        if page != polls.last_page:
-            await message.add_reaction(NEXT_PAGE_EMOJI)
-            await message.add_reaction(LAST_PAGE_EMOJI)
-        else:
-            try:
-                await message.remove_reaction(NEXT_PAGE_EMOJI, self.bot.user)
-                await message.remove_reaction(LAST_PAGE_EMOJI, self.bot.user)
-            except discord.errors.NotFound:
-                pass
 
         try:
             reaction, _ = await self.bot.wait_for(
@@ -375,9 +355,9 @@ class PollsCog(commands.Cog, name="Polls"):
         if emoji == FIRST_PAGE_EMOJI:
             page = 1
         elif emoji == PREVIOUS_PAGE_EMOJI:
-            page -= 1
+            page = (page - 2) % polls.last_page + 1
         elif emoji == NEXT_PAGE_EMOJI:
-            page += 1
+            page = page % polls.last_page + 1
         elif emoji == LAST_PAGE_EMOJI:
             page = polls.last_page
 

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -323,8 +323,9 @@ class PollsCog(commands.Cog, name="Polls"):
             return False
 
         embed = discord.Embed(title="Polls", color=POLL_COLOR,
-                              description="These are all the polls"
-                              if ut.is_admin(user) else "These are your polls")
+                              description=("Showing all the polls"
+                              if ut.is_admin(user) else "Showing your polls")
+                              + " on this server")
         for poll in polls:
             field_value = (
                 (f"by <@!{poll.creator_id}>\n" if ut.is_admin(user) else "")

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -561,6 +561,35 @@ class PollsCog(commands.Cog, name="Polls"):
         if result:
             await ctx.message.delete()
 
+    @commands.command(
+        name="searchpolls",
+        help="Search for polls that you have control over"
+    )
+    async def show_polls(self, ctx, *, search_query):
+        async def query_getter(user):
+            query = Poll.join('users', 'polls.creator_id', '=', 'users.id') \
+                .where('users.guild_id', user.guild.id) \
+                .where('polls.title', 'like', f'%{search_query}%')
+
+            if not ut.is_admin(user):
+                query = query.where('users.id', user.id)
+
+            return query
+
+        desc = f"Showing results for f{search_query} "
+
+        if ut.is_admin(ctx.author):
+            desc += " in all polls" 
+        else:
+            desc += " in your polls"
+
+        result = await self.display_poll_search(
+            query_getter, ctx.author, ctx.channel,
+            desc=desc)
+
+        if result:
+            await ctx.message.delete()
+
 
 def setup(bot):
     """

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -563,7 +563,7 @@ class PollsCog(commands.Cog, name="Polls"):
 
     @commands.command(
         name="searchpolls",
-        help="Search for polls that you have control over"
+        help="Searches for polls that you have control over"
     )
     async def search_polls(self, ctx, *, title):
         async def query_getter(user):

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -565,7 +565,7 @@ class PollsCog(commands.Cog, name="Polls"):
         name="searchpolls",
         help="Search for polls that you have control over"
     )
-    async def show_polls(self, ctx, *, title):
+    async def search_polls(self, ctx, *, title):
         async def query_getter(user):
             query = Poll.join('users', 'polls.creator_id', '=', 'users.id') \
                 .where('users.guild_id', user.guild.id) \

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -319,7 +319,7 @@ class PollsCog(commands.Cog, name="Polls"):
             embed.add_field(
                 name=f"{poll.title}", value=field_value, inline=False)
 
-        first_poll = polls.per_page * (polls.current_page - 1) + 1
+        first_poll = polls.per_page * (page - 1) + 1
         last_poll = first_poll + polls.count() - 1
         total = polls.total
 
@@ -329,8 +329,13 @@ class PollsCog(commands.Cog, name="Polls"):
 
         if message is None:
             message = await channel.send(embed=embed)
-            for emoji in SHOW_POLLS_EMOJI:
-                await message.add_reaction(emoji)
+            if page != 1:
+                await message.add_reaction(FIRST_PAGE_EMOJI)
+                await message.add_reaction(PREVIOUS_PAGE_EMOJI)
+            await message.add_reaction(CLEAR_EMOJI)
+            if page != polls.last_page:
+                await message.add_reaction(NEXT_PAGE_EMOJI)
+                await message.add_reaction(LAST_PAGE_EMOJI)
 
     @tasks.loop(seconds=1.0)
     async def poll_daemon(self):

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -477,6 +477,7 @@ class PollsCog(commands.Cog, name="Polls"):
         name="showpolls",
         help="Shows polls that you have control over")
     async def show_polls(self, ctx):
+        await ctx.message.delete()
         await self.user_show_polls(ctx.author, ctx.channel)
 
 

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -577,15 +577,13 @@ class PollsCog(commands.Cog, name="Polls"):
             return query
 
         desc = f"Showing results for '{title}' "
-
         if ut.is_admin(ctx.author):
-            desc += " in all polls" 
+            desc += " in all polls"
         else:
             desc += " in your polls"
 
         result = await self.display_poll_search(
-            query_getter, ctx.author, ctx.channel,
-            desc=desc)
+            query_getter, ctx.author, ctx.channel, desc=desc)
 
         if result:
             await ctx.message.delete()

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -322,17 +322,27 @@ class PollsCog(commands.Cog, name="Polls"):
             await channel.send("You don't have any polls yet!")
             return False
 
+        description = (
+            "Showing all the polls"
+            if ut.is_admin(user) else "Showing your polls") \
+            + (" on this server\n"
+               f"React with:\n"
+               f"{FIRST_PAGE_EMOJI} to go to the first page\n"
+               f"{PREVIOUS_PAGE_EMOJI} to go to the previous page\n"
+               f"{CLEAR_POLLS_EMOJI} to clear these results\n"
+               f"{NEXT_PAGE_EMOJI} to go to the next page\n"
+               f"{LAST_PAGE_EMOJI} to go to the last page")
+
         embed = discord.Embed(title="Polls", color=POLL_COLOR,
-                              description=("Showing all the polls"
-                              if ut.is_admin(user) else "Showing your polls")
-                              + " on this server")
+                              description=description)
+
         for poll in polls:
             field_value = (
-                (f"by <@!{poll.creator_id}>\n" if ut.is_admin(user) else "")
-                + f"Poll ID: {poll.id}. "
+                (f"by <@!{poll.creator_id}> - " if ut.is_admin(user) else "")
                 + ("Poll has ended" if poll.ended
                    else ut.get_uk_time(poll.end_date).strftime(
-                       "Poll ends: %d/%m/%Y %H:%M:%S %Z\n")))
+                       "Poll ends: %d/%m/%Y %H:%M:%S %Z"))
+                + f"\nPoll ID: {poll.id}.")
 
             embed.add_field(
                 name=f"{poll.title}", value=field_value, inline=False)

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -576,7 +576,7 @@ class PollsCog(commands.Cog, name="Polls"):
 
             return query
 
-        desc = f"Showing results for f{search_query} "
+        desc = f"Showing results for '{search_query}' "
 
         if ut.is_admin(ctx.author):
             desc += " in all polls" 

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -288,14 +288,13 @@ class PollsCog(commands.Cog, name="Polls"):
         # Waits until the bot is ready before starting the task loop
         await self.bot.wait_until_ready()
 
-    @commands.Cog.listener()
-    async def on_raw_reaction_add(self, payload):
+    @commands.Cog.listener('on_raw_reaction_add')
+    async def on_poll_react(self, payload):
         """
         Listens for reactions to poll messages
         """
 
         # Ignores if any bots reacts
-        emoji = payload.emoji
         if payload.member.bot:
             return
 
@@ -312,6 +311,7 @@ class PollsCog(commands.Cog, name="Polls"):
             return
 
         user = payload.member
+        emoji = payload.emoji
         if emoji.name == '✖️':
             deleted = await self.user_delete_poll(poll, message, user)
             if not deleted:
@@ -425,6 +425,12 @@ class PollsCog(commands.Cog, name="Polls"):
         poll.save()
 
         await self.update_response_counts(poll)
+    
+    @commands.command(
+        name="showpolls",
+        help="Shows polls that you have control over")
+    async def show_polls(self, ctx):
+        pass
 
 
 def setup(bot):

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -565,18 +565,18 @@ class PollsCog(commands.Cog, name="Polls"):
         name="searchpolls",
         help="Search for polls that you have control over"
     )
-    async def show_polls(self, ctx, *, search_query):
+    async def show_polls(self, ctx, *, title):
         async def query_getter(user):
             query = Poll.join('users', 'polls.creator_id', '=', 'users.id') \
                 .where('users.guild_id', user.guild.id) \
-                .where('polls.title', 'like', f'%{search_query}%')
+                .where('polls.title', 'like', f'%{title}%')
 
             if not ut.is_admin(user):
                 query = query.where('users.id', user.id)
 
             return query
 
-        desc = f"Showing results for '{search_query}' "
+        desc = f"Showing results for '{title}' "
 
         if ut.is_admin(ctx.author):
             desc += " in all polls" 

--- a/cogs/polls.py
+++ b/cogs/polls.py
@@ -308,7 +308,8 @@ class PollsCog(commands.Cog, name="Polls"):
 
         def check(reaction, check_user):
             return (str(reaction.emoji) in SHOW_POLLS_EMOJI
-                    and check_user == user)
+                    and check_user == user
+                    and reaction.message.id == message.id)
 
         query = Poll.join('users', 'polls.creator_id', '=', 'users.id') \
             .where('users.guild_id', channel.guild.id)

--- a/utils.py
+++ b/utils.py
@@ -47,25 +47,25 @@ async def get_confirmation(channel, user, bot, message):
         return False, "Rejected"
 
 
-async def get_utc_time(timestamp: int = None) -> datetime.datetime:
+def get_utc_time(timestamp: int = None) -> datetime.datetime:
     if timestamp is None:
         return datetime.datetime.utcnow()
 
     return datetime.datetime.utcfromtimestamp(timestamp)
 
 
-async def get_uk_time(utc_time: datetime.datetime = None) -> datetime.datetime:
+def get_uk_time(utc_time: datetime.datetime = None) -> datetime.datetime:
     # Converts a naive datetime to an aware datetime in UTC
     utc_time = utc_time.replace(tzinfo=datetime.timezone.utc)
 
     tz = timezone('Europe/London')
     if utc_time is None:
-        return (await get_utc_time()).astimezone(tz)
+        return get_utc_time().astimezone(tz)
 
     return utc_time.astimezone(tz)
 
 
-async def is_admin(user):
+def is_admin(user):
     for role in user.roles:
         if role.name.lower() == "admin":
             return True


### PR DESCRIPTION
# Features

## `showpolls` command

- This command show polls that are available to be controlled by the user. In the case of regular members, these are polls that have been created by the member, and for admins these are all polls
- Optionally, a title argument can be specified to show polls whose titles contain the expression in the argument
- In all cases, only polls started on that guild can be viewed

# Minor changes

- Response counts/results for polls are only called for update when required, rather than in the poll task loop every iteration
    - Previously, embed fields were sorted and compared to determine whether or not they had changed before updating the embed in the message
- Change some util methods to regular methods, where there was no benefit to having them as coroutine functions
- Extract constants from code